### PR TITLE
fix json output in css with libsass, quotes and double quote were wrong

### DIFF
--- a/_mediaqueries.scss
+++ b/_mediaqueries.scss
@@ -56,6 +56,6 @@ $mediaJSON: $mediaJSON + '}';
 // an element with this class will be created with JS in order to parse the JSON content
 .js-breakpoint:after,
 .js-breakpoint {
-  content: "#{$mediaJSON}";
-  font-family: "#{$mediaJSON}";
+  content: "'" + #{$mediaJSON} + "'";
+  font-family: "'" + #{$mediaJSON} + "'";
 }


### PR DESCRIPTION
Before the patch the css code looked like this with libsass:

    .js-breakpoint:after, .js-breakpoint {
      content: "{"mobile-portrait":"only screen and (max-width:400px)","mobile":"only screen and (max-width:740px)","not-mobile":"only screen and (min-width:741px)","only-mobile":"only screen and (max-width:740px)","tablet-portrait":"only screen and (max-width:850px)","tablet":"only screen and (max-width:1050px)","only-tablet":"only screen and (min-width:741px) and (max-width:1051px)","not-tablet":"only screen and (min-width:1051px)","desktop":"only screen and (min-width:1051px)","only-desktop":"only screen and (min-width:1051px)","retina":"only screen and (-webkit-min-device-pixel-ratio : 1.5), only screen and (min-device-pixel-ratio : 1.5)","highres":"print, (-o-min-device-pixel-ratio: 5/4), (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)","print":"print"}";
      font-family: "{"mobile-portrait":"only screen and (max-width:400px)","mobile":"only screen and (max-width:740px)","not-mobile":"only screen and (min-width:741px)","only-mobile":"only screen and (max-width:740px)","tablet-portrait":"only screen and (max-width:850px)","tablet":"only screen and (max-width:1050px)","only-tablet":"only screen and (min-width:741px) and (max-width:1051px)","not-tablet":"only screen and (min-width:1051px)","desktop":"only screen and (min-width:1051px)","only-desktop":"only screen and (min-width:1051px)","retina":"only screen and (-webkit-min-device-pixel-ratio : 1.5), only screen and (min-device-pixel-ratio : 1.5)","highres":"print, (-o-min-device-pixel-ratio: 5/4), (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)","print":"print"}"; }


With this fix it now looks like this (and can be parsed by js):

    .js-breakpoint:after, .js-breakpoint {
      content: '{"mobile-portrait":"only screen and (max-width:400px)","mobile":"only screen and (max-width:740px)","not-mobile":"only screen and (min-width:741px)","only-mobile":"only screen and (max-width:740px)","tablet-portrait":"only screen and (max-width:850px)","tablet":"only screen and (max-width:1050px)","only-tablet":"only screen and (min-width:741px) and (max-width:1051px)","not-tablet":"only screen and (min-width:1051px)","desktop":"only screen and (min-width:1051px)","only-desktop":"only screen and (min-width:1051px)","retina":"only screen and (-webkit-min-device-pixel-ratio : 1.5), only screen and (min-device-pixel-ratio : 1.5)","highres":"print, (-o-min-device-pixel-ratio: 5/4), (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)","print":"print"}';
      font-family: '{"mobile-portrait":"only screen and (max-width:400px)","mobile":"only screen and (max-width:740px)","not-mobile":"only screen and (min-width:741px)","only-mobile":"only screen and (max-width:740px)","tablet-portrait":"only screen and (max-width:850px)","tablet":"only screen and (max-width:1050px)","only-tablet":"only screen and (min-width:741px) and (max-width:1051px)","not-tablet":"only screen and (min-width:1051px)","desktop":"only screen and (min-width:1051px)","only-desktop":"only screen and (min-width:1051px)","retina":"only screen and (-webkit-min-device-pixel-ratio : 1.5), only screen and (min-device-pixel-ratio : 1.5)","highres":"print, (-o-min-device-pixel-ratio: 5/4), (-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)","print":"print"}'; }
