### PR TITLE
Adds matchQuery.js as a bower dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Alternatively you can require mediaQuery.js with AMD.
 require(['lib/browser/mediaQuery'], function ( mediaQuery ) {})
 ```
 
+Note: If you support IE9 and below, make sure you include [matchMedia.js](https://github.com/paulirish/matchMedia.js). If you use bower, this should already be in your ```bower_components``` folder as it is a sensible dependency.
+
 
 ## Usage SCSS
 

--- a/bower.json
+++ b/bower.json
@@ -29,6 +29,7 @@
         "README.md"
     ],
     "dependencies": {
+        "matchMedia.js": "0.2.0",
         "jquery": ">=1.10.2"
     }
 }


### PR DESCRIPTION
matchQuery.js is giving an error on IE9 in line 62:

https://github.com/meodai/sensible/blob/master/mediaQuery.js#L62

![screen shot 2015-05-06 at 16 05 15](https://cloud.githubusercontent.com/assets/389459/7494890/c6cf4c1a-f40a-11e4-9fe6-11a5c491216f.png)


This PR adds matchMedia.js polyfill as a dependency so it should download the dependency on projects that use sensible via bower. 