### PR TITLE
Fixes the matchMedia.js dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
         "README.md"
     ],
     "dependencies": {
-        "matchMedia.js": "0.2.0",
+        "matchMedia": "0.2.0",
         "jquery": ">=1.10.2"
     }
 }


### PR DESCRIPTION
Apparently the name changed and now you can't install sensible through bower because of this.