### PR TITLE
Adds error catching to the parsing of the string

### DIFF
--- a/mediaQuery.js
+++ b/mediaQuery.js
@@ -54,7 +54,16 @@
 
   // parses the JSON given from the CSS
   parseJSONString = function (queryJSONString) {
-    return JSON.parse( queryJSONString.replace(/^['"]+|\\|(;\s?)+|['"]$/g, '') );
+    var queriesObject = {};
+    queryJSONString = queryJSONString.replace(/^['"]+|\\|(;\s?)+|['"]$/g, '');
+
+    try{
+        queriesObject = JSON.parse(queryJSONString);
+    }catch(e){
+        $.error('Sensible mediaQuery error. The query string in the DOM was not a JSON object: ' + queryJSONString);
+    }
+
+    return queriesObject;
   };
 
   // checks if queryKey exists in queries and if matchMedia matches


### PR DESCRIPTION
When the string is not an object, the error is really hard to track down.
This adds nice error logging to the parsing.

Before:
![image](https://cloud.githubusercontent.com/assets/1759/8080231/0529dfae-0f6b-11e5-8217-19760625c291.png)


After:
![image](https://cloud.githubusercontent.com/assets/1759/8080263/2e15b6ea-0f6b-11e5-860b-c3aca2c6ed14.png)

